### PR TITLE
Fix default view item lost on checkin

### DIFF
--- a/cfg/versions.cfg
+++ b/cfg/versions.cfg
@@ -104,3 +104,5 @@ templer.zope = 1.0b2
 #isaw.policy 1.0-dev
 z3c.jbot = 0.7.2
 
+# upgrade plone.app.iterate to solve https://github.com/isawnyu/isaw.web/issues/56
+plone.app.iterate = 2.1.14


### PR DESCRIPTION
This PR fixes #56 by updating plone.app.iterate to get the fix for the issue implemented there.  

@alecpm this should be ready to merge.

@paregorios, once this is deployed to staging, the effect should be immediate.  There is no need to update the add-on.  The fix occurs during check-in of existing working copies, so there is also no need to re-create any working copies that are default views.  They should still be default view after checkin happens.  