### PR TITLE
#51: unbind workflow for News Item and Event types

### DIFF
--- a/src/isaw.policy/src/isaw/policy/profiles/default/workflows.xml
+++ b/src/isaw.policy/src/isaw/policy/profiles/default/workflows.xml
@@ -6,7 +6,7 @@
 <object name="isaw_standard_workflow" meta_type="Workflow"/>
 <bindings>
 <default>
-<bound-workflow workflow_id="isaw_standard_workflow"/>
+ <bound-workflow workflow_id="isaw_standard_workflow"/>
 </default>
 <type type_id="ATBooleanCriterion"/>
 <type type_id="ATCurrentAuthorCriterion"/>
@@ -22,19 +22,13 @@
 <type type_id="ATSimpleStringCriterion"/>
 <type type_id="ATSortCriterion"/>
 <type type_id="Discussion Item">
-<bound-workflow workflow_id="one_state_workflow"/>
-</type>
-<type type_id="Event">
-<bound-workflow workflow_id="isaw_reviewer_workflow"/>
+ <bound-workflow workflow_id="one_state_workflow"/>
 </type>
 <type type_id="File">
  <bound-workflow workflow_id="one_state_workflow"/>
 </type>
 <type type_id="Image">
  <bound-workflow workflow_id="one_state_workflow"/>
-</type>
-<type type_id="News Item">
-<bound-workflow workflow_id="isaw_reviewer_workflow"/>
 </type>
 <type type_id="Plone Site"/>
 </bindings>


### PR DESCRIPTION
This PR removes binding for the Event and NewsItem content types.  It should not require an upgrade step, as it is codification in code of a change that has already been made manually on the production server.  

refs #51