### PR TITLE
#100: Add a title-only listing for collections and folders

### DIFF
--- a/src/isaw.theme/isaw/theme/browser/configure.zcml
+++ b/src/isaw.theme/isaw/theme/browser/configure.zcml
@@ -49,16 +49,6 @@
     template="templates/tiled_view.pt"
     />
 
-  <!-- Event listing view -->
-  <browser:page
-    name="event-listing"
-    for="*"
-    permission="zope2.View"
-    class=".event_listing.EventListingView"
-    layer=".interfaces.IThemeSpecific"
-    template="templates/event_listing.pt"
-    />
-
     <browser:menuItem
         for="Products.ATContentTypes.interface.IATFolder"
         menu="plone_displayviews"
@@ -81,30 +71,6 @@
         title="Tiled Listing"
         action="@@tiled-listing"
         description="List folder contents in a 3x3 grid of tiles"
-        />
-
-    <browser:menuItem
-        for="Products.ATContentTypes.interface.IATFolder"
-        menu="plone_displayviews"
-        title="Event Listing"
-        action="@@event-listing"
-        description="List events in single column page"
-        />
-
-    <browser:menuItem
-        for="Products.ATContentTypes.interface.IATTopic"
-        menu="plone_displayviews"
-        title="Event Listing"
-        action="@@event-listing"
-        description="List events in single column page"
-        />
-
-    <browser:menuItem
-        for="plone.app.collection.interfaces.ICollection"
-        menu="plone_displayviews"
-        title="Event Listing"
-        action="@@event-listing"
-        description="List events in single column page"
         />
 
     <browser:viewlet
@@ -126,6 +92,40 @@
         template="templates/tiled_list_items.pt"
         />
 
+  <!-- Event listing view -->
+  <browser:page
+    name="event-listing"
+    for="*"
+    permission="zope2.View"
+    class=".event_listing.EventListingView"
+    layer=".interfaces.IThemeSpecific"
+    template="templates/event_listing.pt"
+    />
+
+    <browser:menuItem
+        for="Products.ATContentTypes.interface.IATFolder"
+        menu="plone_displayviews"
+        title="Event Listing"
+        action="@@event-listing"
+        description="List events in single column page"
+        />
+
+    <browser:menuItem
+        for="Products.ATContentTypes.interface.IATTopic"
+        menu="plone_displayviews"
+        title="Event Listing"
+        action="@@event-listing"
+        description="List events in single column page"
+        />
+
+    <browser:menuItem
+        for="plone.app.collection.interfaces.ICollection"
+        menu="plone_displayviews"
+        title="Event Listing"
+        action="@@event-listing"
+        description="List events in single column page"
+        />
+
     <browser:page
         name="event-listing-page"
         for="*"
@@ -133,6 +133,40 @@
         class=".event_listing.EventListingView"
         layer=".interfaces.IThemeSpecific"
         template="templates/list_events.pt"
+        />
+
+  <!-- Title listing view -->
+  <browser:page
+    name="title-listing"
+    for="*"
+    permission="zope2.View"
+    class=".title_listing_view.TitleListingView"
+    layer=".interfaces.IThemeSpecific"
+    template="templates/title_view.pt"
+    />
+
+    <browser:menuItem
+        for="Products.ATContentTypes.interface.IATFolder"
+        menu="plone_displayviews"
+        title="Title-Only Listing"
+        action="@@title-listing"
+        description="List folder contents by title only"
+        />
+
+    <browser:menuItem
+        for="Products.ATContentTypes.interface.IATTopic"
+        menu="plone_displayviews"
+        title="Title-Only Listing"
+        action="@@title-listing"
+        description="List folder contents by title only"
+        />
+
+    <browser:menuItem
+        for="plone.app.collection.interfaces.ICollection"
+        menu="plone_displayviews"
+        title="Title-Only Listing"
+        action="@@title-listing"
+        description="List folder contents by title only"
         />
 
   <!-- byline viewlet available on any contentish (non-folder) AT item -->

--- a/src/isaw.theme/isaw/theme/browser/interfaces.py
+++ b/src/isaw.theme/isaw/theme/browser/interfaces.py
@@ -36,6 +36,13 @@ class ITiledListingView(Interface):
     """
 
 
+class ITitleListingView(Interface):
+    """marker interface for a view providing listing by title only
+
+    This view is suitable for folders or collections
+    """
+
+
 class IEventListingView(Interface):
     """marker interface for a view providing one column listed items
 

--- a/src/isaw.theme/isaw/theme/browser/templates/title_view.pt
+++ b/src/isaw.theme/isaw/theme/browser/templates/title_view.pt
@@ -1,0 +1,31 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="isaw.theme">
+<body>
+
+<metal:content-core fill-slot="content-core">
+<metal:block define-macro="content-core"
+                    tal:define="kssClassesView context/@@kss_field_decorator_view;
+                                getKssClasses nocall:kssClassesView/getKssClassesInlineEditable;
+                                templateId template/getId">
+  <div id="title-listing-container" tal:define="items view/listings">
+    <ul class="title-listing">
+     <tal:block tal:repeat="item items">
+      <li tal:define="title item/Title;
+                      url item/getURL">
+        <a href="" tal:attributes="href url;
+                                   alt title"
+                   tal:content="title">[Item Title]</a>                
+      </li>
+     </tal:block>
+    </ul>
+  </div>
+</metal:block>
+</metal:content-core>
+
+</body>
+</html>

--- a/src/isaw.theme/isaw/theme/browser/title_listing_view.py
+++ b/src/isaw.theme/isaw/theme/browser/title_listing_view.py
@@ -1,0 +1,55 @@
+from Products.Five.browser import BrowserView
+from zope.interface import implements
+
+from isaw.theme.browser.interfaces import ITitleListingView
+
+
+class TitleListingView(BrowserView):
+    """view class"""
+    implements(ITitleListingView)
+    batch_size = 0
+    page = 1
+
+    def __init__(self, request, context):
+        super(TitleListingView, self).__init__(request, context)
+        self.page = int(self.request.get('page', 1))
+
+    def _query(self, query=None, exclude=None, b_start=None, b_size=None):
+        if b_size is None:
+            b_size = self.batch_size
+        if b_start is None:
+            b_start = (getattr(self, 'page', 1) - 1) * b_size
+
+        if query is None:
+            query = {}
+
+        if exclude is not None:
+            uuid = getattr(exclude, 'UID')
+            if callable(uuid):
+                uuid = uuid()
+            if uuid:
+                query['UID'] = {'not': uuid}
+
+        if self.context.portal_type == 'Folder':
+            self.request['b_start'] = b_start
+            self.request['b_size'] = b_size
+            query['b_start'] = b_start
+            query['b_size'] = b_size
+            items = self.context.getFolderContents(contentFilter=query,
+                                                   batch=True, b_size=b_size)
+        elif self.context.portal_type == 'Topic':
+            if b_start and not self.request.get('b_start'):
+                self.request['b_start'] = b_start
+            items = self.context.queryCatalog(self.request, True, b_size,
+                                              **query)
+        elif self.context.portal_type == 'Collection':
+            items = self.context.results(True, b_start, b_size,
+                                         custom_query=query)
+        else:
+            items = []
+
+        return items
+
+    def listings(self, b_start=None, b_size=None):
+        """get a page of listings"""
+        return self._query(b_start=b_start, b_size=b_size)

--- a/src/isaw.theme/isaw/theme/profiles.zcml
+++ b/src/isaw.theme/isaw/theme/profiles.zcml
@@ -229,4 +229,14 @@
       import_steps="tinymce_settings"
       />
 
+  <genericsetup:upgradeDepends
+      sortkey="10"
+      source="21"
+      destination="22"
+      title="Title Listing View"
+      description="Add a view for collections and folders showing item titles only"
+      profile="isaw.theme:default"
+      import_steps="typeinfo"
+      />
+
 </configure>

--- a/src/isaw.theme/isaw/theme/profiles/default/metadata.xml
+++ b/src/isaw.theme/isaw/theme/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>21</version>
+  <version>22</version>
   <dependencies>
     <dependency>profile-plone.app.theming:default</dependency>
     <dependency>profile-collective.navigationtoggle:default</dependency>

--- a/src/isaw.theme/isaw/theme/profiles/default/types/Collection.xml
+++ b/src/isaw.theme/isaw/theme/profiles/default/types/Collection.xml
@@ -7,5 +7,6 @@
         <!-- We retrofit these new views for Folders in portal_types info -->
         <element value="tiled-listing"/>
         <element value="event-listing"/>
+        <element value="title-listing"/>
     </property>
 </object>

--- a/src/isaw.theme/isaw/theme/profiles/default/types/Folder.xml
+++ b/src/isaw.theme/isaw/theme/profiles/default/types/Folder.xml
@@ -8,5 +8,6 @@
         <element value="tiled-listing"/>
         <element value="event-listing"/>
         <element value="people-listing"/>
+        <element value="title-listing"/>
     </property>
 </object>

--- a/src/isaw.theme/isaw/theme/profiles/default/types/Topic.xml
+++ b/src/isaw.theme/isaw/theme/profiles/default/types/Topic.xml
@@ -7,5 +7,6 @@
         <!-- We retrofit these new views for Folders in portal_types info -->
         <element value="tiled-listing"/>
         <element value="event-listing"/>
+        <element value="title-listing"/>
     </property>
 </object>

--- a/src/isaw.theme/isaw/theme/static/theme.css
+++ b/src/isaw.theme/isaw/theme/static/theme.css
@@ -536,6 +536,12 @@ body.template-newsitem_view .newsImageContainer p.discreet {width: 95%; font-sty
 .section-people #portal-columns .facultyListing .facultyInfo p.facultyEmail {font-weight:300;  }
 
 
+/* title listing view */
+#title-listing-container ul.title-listing{
+    list-style: none;
+}
+
+
 /* full cal */
 #portal-columns table.fc-header,
 #portal-columns table.fc-header table,


### PR DESCRIPTION
This PR implements a simple, title-only view of a collection or folder.  

When selected as the display for a folder or collection, the view will display *all* items in that folder or collection as a list of titles, linked to the items they represent.  

Very little styling has been done, other than to suppress the bullets for the unordered list items.  There is room for more to be done there, but in the absence of a mockup, this is a good, neutral starting point.

refs #100 