### PR TITLE
Remove 'display:none' style from OK button when showing it

### DIFF
--- a/src/isaw.theme/isaw/theme/browser/template-overrides/Products.TinyMCE.skins.tinymce.plugins.plonebrowser.js.plonebrowser.js
+++ b/src/isaw.theme/isaw/theme/browser/template-overrides/Products.TinyMCE.skins.tinymce.plugins.plonebrowser.js.plonebrowser.js
@@ -1097,7 +1097,7 @@ BrowserDialog.prototype.displayPanel = function(panel, upload_allowed) {
         jq('#email_panel', document).removeClass('hide');
         // move the common link fileds to appropriate location
         jq('#email_panel', document).append(jq('#common-link-fields', document).removeClass('hide'));
-        jq('#insert-selection', document).removeAttr('disabled');
+        jq('#insert-selection', document).removeAttr('disabled').show().removeAttr("style");
     } else {
         jq('#email_panel', document).addClass('hide');
     }
@@ -1106,7 +1106,7 @@ BrowserDialog.prototype.displayPanel = function(panel, upload_allowed) {
         jq('#anchor_panel', document).removeClass('hide');
         // move the common link fileds to appropriate location
         jq('#anchorlinkcontainer', document).append(jq('#common-link-fields', document).removeClass('hide'));
-        jq('#insert-selection', document).removeAttr('disabled');
+        jq('#insert-selection', document).removeAttr('disabled').show().removeAttr("style");
     } else {
         jq('#anchor_panel', document).addClass('hide');
     }
@@ -1115,8 +1115,7 @@ BrowserDialog.prototype.displayPanel = function(panel, upload_allowed) {
         jq('#external_panel', document).removeClass('hide');
         // move the common link fileds to appropriate location
         jq('#external-column', document).append(jq('#common-link-fields', document).removeClass('hide'));
-        jq('#insert-selection', document).show();
-        jq('#insert-selection', document).removeAttr('disabled');
+        jq('#insert-selection', document).show().removeAttr("style").removeAttr('disabled');
     } else {
         jq('#external_panel', document).addClass('hide');
     }
@@ -1150,8 +1149,7 @@ BrowserDialog.prototype.displayPanel = function(panel, upload_allowed) {
         if( jq('#internal_link:visible', document).length > 0) {
             jq('#details-fields', document).append(jq('#common-link-fields', document).removeClass('hide'));
         }
-        jq('#insert-selection', document).removeAttr('disabled');
-        jq('#insert-selection', document).show();
+        jq('#insert-selection', document).removeAttr('disabled').show().removeAttr("style");
     } else {
         jq('#details_panel', document).addClass('hide');
     }
@@ -1165,7 +1163,7 @@ BrowserDialog.prototype.displayPanel = function(panel, upload_allowed) {
     // handle external image
     if (panel === "externalimage") {
         jq('#externalimage_panel', document).removeClass('hide');
-        jq('#insert-selection', document).removeAttr('disabled');
+        jq('#insert-selection', document).removeAttr('disabled').show().removeAttr("style");
         jq('#imagetitle', document).parents('.field').after(jq('#classes', document).parents('.field'));
     } else {
         jq('#externalimage_panel', document).addClass('hide');


### PR DESCRIPTION
See https://github.com/isawnyu/isaw.web/issues/435

In TinyMCE, in the modal window that appears after clicking the link icon, the OK button disappears when switching to the `Internal` tab if no element in that tab is selected (so far so good). If the user clicks `Email` or `Anchor` after that, the button does not appear. After some investigation I found it had a `style="display: none"` attribute set. This PR adds code to remove that attribute when the button is supposed to be visible.