### PR TITLE
Remove byline from folder_leadimage_view.pt

### DIFF
--- a/src/isaw.theme/isaw/theme/browser/template-overrides/collective.contentleadimage.browser.folder_leadimage_view.pt
+++ b/src/isaw.theme/isaw/theme/browser/template-overrides/collective.contentleadimage.browser.folder_leadimage_view.pt
@@ -122,46 +122,6 @@
                         </a>
                     </h2>
 
-                    <div class="documentByLine" tal:condition="python: site_properties.allowAnonymousViewAbout or not isAnon">
-                    <tal:event condition="python: item_type == 'Event'">
-                         <span tal:condition="python: item_type == 'Event'"
-                               i18n:translate="label_event_byline">
-                             (<span tal:content="string:${item/location}"
-                                    class="location"
-                                    i18n:name="location">Oslo</span><tal:comma
-                                    tal:replace="string:, "
-                                    tal:condition="item/location" />from
-                              <abbr class="dtstart"
-                                    tal:attributes="title python:item_start"
-                                    tal:content="python:toLocalizedTime(item_start,long_format=1)"
-                                    i18n:name="start">from date</abbr> to
-                              <abbr class="dtend"
-                                    tal:attributes="title python:item_end"
-                                    tal:content="python:toLocalizedTime(item_end,long_format=1)"
-                                    i18n:name="end">to date</abbr>)
-                         </span>
-                    </tal:event>
-                    <tal:newsitem condition="python: item_type == 'News Item'">
-                        <tal:name tal:condition="item_creator"
-                            tal:define="mtool mtool|context/portal_membership; author python:mtool.getMemberInfo(item_creator)">
-                          <span i18n:translate="label_by_author">
-                            by
-                          <a href="#"
-                             tal:attributes="href string:${portal_url}/author/${item_creator}"
-                             tal:content="python:author and author['fullname'] or item_creator"
-                             tal:omit-tag="not:author"
-                             i18n:name="author">
-                            Bob Dobalina
-                          </a>
-                          </span>
-                        </tal:name>
-                        &mdash;
-                        <span tal:replace="python:toLocalizedTime(item_modified,long_format=1)">
-                        August 16, 2001 at 23:35:59
-                        </span>
-                    </tal:newsitem>
-                    </div>
-
                     <p class="tileBody" tal:define="item_portal_type item/portal_type">
                         <span tal:omit-tag="" tal:condition="python: item_portal_type != 'profile' and not item_description">
                             &nbsp;


### PR DESCRIPTION
See [#403](https://github.com/isawnyu/isaw.web/issues/443).

Removes byline display for `Event` and `News Item` on `Lead image folder` view.