### PR TITLE
Remove everything related to the collective.addthis addon

### DIFF
--- a/cfg/versions.cfg
+++ b/cfg/versions.cfg
@@ -105,10 +105,6 @@ tarjan = 0.2.3.2
 prettyconf = 1.2.3
 
 #Required by:
-#isaw.theme 0.4
-collective.addthis = 1.3.3
-
-#Required by:
 #compoze 1.0
 pkginfo = 1.2b1
 

--- a/scripts/remove_addthis_addon.py
+++ b/scripts/remove_addthis_addon.py
@@ -1,0 +1,45 @@
+from zope.component.hooks import setSite
+from plone.browserlayer import utils
+import transaction
+
+
+site = app.unrestrictedTraverse('/isaw')
+setSite(site)
+
+# Remove all registry entries
+registry = site.portal_registry
+to_delete = [k for k in registry.records.keys() if 'addthis' in k.lower()]
+
+if not to_delete:
+    print("No AddThis registry records found.")
+else:
+    for key in to_delete:
+        del registry.records[key]
+        print("Deleted registry key:", key)
+
+# Remove control panel action
+cp = site.portal_controlpanel
+
+actions = list(cp.listActions())
+found = False
+
+for index, action in enumerate(actions):
+    if action.id == "addthis-settings":
+        print("Deleting control panel action:", action.id, "-", action.title)
+        cp.deleteActions([index])
+        found = True
+        break
+
+if not found:
+    print("No AddThis-related control panel action found.")
+
+# Remove browser layer
+try:
+    utils.unregister_layer(
+        name="collective.addthis"
+    )
+    print("Removed collective.addthis browser layer.")
+except KeyError:
+    print("collective.addthis was not registered.")
+
+transaction.commit()

--- a/src/isaw.theme/isaw/theme/static/rules.xml
+++ b/src/isaw.theme/isaw/theme/static/rules.xml
@@ -189,9 +189,6 @@
     <after method="raw" css:theme-children="#portal-column-second"
         css:content=".calendar-view-link" />
 
-    <!-- addthis buttons are out -->
-    <drop css:content="#socialtools" />
-
     <!-- drop bad accessibility elements -->
     <drop content="//*[@accesskey='']" attributes="accesskey" />
     <drop content="//a[@title]" attributes="title" />

--- a/src/isaw.theme/setup.py
+++ b/src/isaw.theme/setup.py
@@ -26,7 +26,6 @@ setup(name='isaw.theme',
       install_requires=[
           'setuptools',
           # -*- Extra requirements: -*-
-          'collective.addthis',
           'plone.app.theming',
           'Products.ZCatalog>=3.0.2',
       ],


### PR DESCRIPTION
Related to issue #495 .

This PR removes the `collective.addthis` addon from the buildout.

Since this addon does not provide an uninstall profile in order to fully remove all related persistent objects a script was written that should:
* remove registry entries
* remove the control panel configlet (which caused the `Configure addthis` entry leading to a broken link to be present)
* unregister the `collective.addthis.interfaces.IAddThisBrowserLayer` browser layer which was causing a warning (since it can no longer be imported)

So after running the buildout some steps are needed:
* run the `remove_addthis_addon.py` with `bin/client1 run scripts/remove_addthis_addon.py`
* manually remove the egg from the eggs folder `rm -rf eggs/collective.addthis-1.3.3-py2.7.egg/`