### PR TITLE
Fix images captions and sizes

### DIFF
--- a/src/isaw.theme/isaw/theme/configure.zcml
+++ b/src/isaw.theme/isaw/theme/configure.zcml
@@ -13,6 +13,16 @@
   <include file="skins.zcml" />
   <include file="profiles.zcml" />
 
+  <!-- Enable resolveuid and caption filters -->
+  <utility
+      provides="plone.outputfilters.filters.resolveuid_and_caption.IResolveUidsEnabler"
+      component=".resolveuid_and_caption.AlwaysResolveUidsEnabler"
+      />
+  <utility
+      provides="plone.outputfilters.filters.resolveuid_and_caption.IImageCaptioningEnabler"
+      component=".resolveuid_and_caption.AlwaysImageCaptioningEnabler"
+      />
+
   <plone:static directory="static" type="theme" />
 
   <browser:page name="theme-enabled"


### PR DESCRIPTION
Related to issue #580 .

This PR should fix images captions and width/height.
We are ensuring captioning feature is enabled:

```
The captioning filter is enabled if there is at least one plone.outputfilters.filters.resolveuid_and_caption.IImageCaptioningEnabler utility whose available property returns True. This mechanism exists for compatibility with TinyMCE and kupu, which both provide their own control panel setting to enable the captioning feature.
```

 ([source](https://github.com/plone/plone.outputfilters/blob/master/README.rst#image-captioning))

We are also updating our customized code to ensure required attributes are being properly set.