### PR TITLE
Fix calendar portlet

### DIFF
--- a/cfg/versions.cfg
+++ b/cfg/versions.cfg
@@ -82,7 +82,7 @@ pycparser = 2.21
 
 plone.app.imagecropping = >=2.0,<3
 Products.RedirectionTool = 1.4.1
-Products.DateRecurringIndex = 2.1
+Products.DateRecurringIndex = 3.0.1
 collective.elephantvocabulary = 0.2.5
 icalendar = 3.10
 plone.event = 1.3


### PR DESCRIPTION
This PR should fix the calendar portlet on Plone 5.2 (issue #606 ).

The issue is caused by the missing `_convert` method on the [`Products.DateRecurringIndex`](https://github.com/collective/Products.DateRecurringIndex/blob/2.x/src/Products/DateRecurringIndex/index.py#L35) on the Python 2 branch.

I decided to upgrade the package to the `3.x` branch since this solved the problem without causing any issues (at least i couldn't find any).
Another approach may be to monkey patch the  `DateRecurringIndex` class on startup to implement the `_convert` method.